### PR TITLE
fix: filter replays page to show only user's own replays

### DIFF
--- a/src/app/replays/page.tsx
+++ b/src/app/replays/page.tsx
@@ -63,10 +63,11 @@ export default function ReplaysPage() {
           return;
         }
 
-        // Fetch replays from the database
+        // Fetch replays from the database (filtered by current user)
         const { data, error } = await supabase
           .from('replays')
           .select('*')
+          .eq('user_id', session.user.id)
           .order('created_at', { ascending: false });
 
         if (error) {


### PR DESCRIPTION
## Summary                                             
 - Adds missing user_id filter to the replays page query                 
 - Security fix: users could previously see all users' replays           
 ## Changes                                                             
 - src/app/replays/page.tsx: Added .eq('user_id', session.user.id)       
                                                                         
 ## Test Plan                                                            
 - [x] Verified only own replays shown on /replays                       
 - [x] Verified /showcase still shows public replays                     
 - [x] Verified upload flow works                                        
 - [x] Build passes