### PR TITLE
Support dual recommendation API modes (deterministic + agentic)

### DIFF
--- a/src/__tests__/unit/SongRecommendations.spec.tsx
+++ b/src/__tests__/unit/SongRecommendations.spec.tsx
@@ -1,0 +1,419 @@
+// ABOUTME: Unit tests for SongRecommendations component.
+// ABOUTME: Validates conditional rendering for deterministic vs agentic profile modes.
+
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import SongRecommendations from '@/components/SongRecommendations';
+
+// --- Mocks ---
+
+// Mock motion/react
+jest.mock('motion/react', () => ({
+  motion: {
+    div: ({
+      children,
+      ...props
+    }: {
+      children: React.ReactNode;
+      [key: string]: any;
+    }) => <div {...props}>{children}</div>,
+  },
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+// Mock lucide-react icons
+jest.mock('lucide-react', () => ({
+  Music: () => <span data-testid="icon-music">Music</span>,
+  Loader2: ({ className }: { className?: string }) => (
+    <span data-testid="icon-loader" className={className}>
+      Loader
+    </span>
+  ),
+  Zap: () => <span data-testid="icon-zap">Zap</span>,
+  Users: () => <span data-testid="icon-users">Users</span>,
+  Trophy: () => <span data-testid="icon-trophy">Trophy</span>,
+  Target: () => <span data-testid="icon-target">Target</span>,
+  RefreshCw: () => <span data-testid="icon-refresh">Refresh</span>,
+}));
+
+// Mock UI components
+jest.mock('@/components/ui/card', () => {
+  const Card = ({
+    children,
+    className,
+  }: {
+    children: React.ReactNode;
+    className?: string;
+  }) => (
+    <div data-testid="card" className={className}>
+      {children}
+    </div>
+  );
+  Card.displayName = 'Card';
+
+  const CardContent = ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="card-content">{children}</div>
+  );
+  CardContent.displayName = 'CardContent';
+
+  const CardHeader = ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="card-header">{children}</div>
+  );
+  CardHeader.displayName = 'CardHeader';
+
+  const CardTitle = ({
+    children,
+    className,
+  }: {
+    children: React.ReactNode;
+    className?: string;
+  }) => (
+    <h2 data-testid="card-title" className={className}>
+      {children}
+    </h2>
+  );
+  CardTitle.displayName = 'CardTitle';
+
+  return { Card, CardContent, CardHeader, CardTitle };
+});
+
+jest.mock('@/components/ui/button', () => {
+  const Button = ({
+    children,
+    onClick,
+    disabled,
+    variant,
+    className,
+    ...props
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+    variant?: string;
+    className?: string;
+    [key: string]: any;
+  }) => (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      data-variant={variant}
+      className={className}
+    >
+      {children}
+    </button>
+  );
+  Button.displayName = 'Button';
+  return { Button };
+});
+
+jest.mock('@/components/ui/badge', () => {
+  const Badge = ({
+    children,
+    className,
+    variant,
+  }: {
+    children: React.ReactNode;
+    className?: string;
+    variant?: string;
+  }) => (
+    <span data-testid="badge" className={className} data-variant={variant}>
+      {children}
+    </span>
+  );
+  Badge.displayName = 'Badge';
+  return { Badge };
+});
+
+jest.mock('@/components/ui/use-toast', () => ({
+  useToast: () => ({
+    toast: jest.fn(),
+  }),
+}));
+
+// Mock SpotifySongCard as a simple div (per navbar pattern)
+jest.mock('@/components/SpotifySongCard', () => {
+  const MockSpotifySongCard = ({ song, index }: { song: any; index: number }) => (
+    <div data-testid={`song-card-${index}`}>
+      {song.title} by {song.artist}
+    </div>
+  );
+  MockSpotifySongCard.displayName = 'SpotifySongCard';
+  return MockSpotifySongCard;
+});
+
+// --- Fixtures ---
+
+const deterministicResult = {
+  success: true,
+  profile: {
+    player_name: 'TestPlayer',
+    metrics: {
+      intensity_score: 75,
+      performance_score: 80,
+      teamwork_factor: 60,
+      game_outcome: 'win',
+    },
+    categories: {
+      intensity: 'High',
+      performance: 'Excellent',
+      teamwork: 'Good',
+      closeness: 'Medium',
+    },
+    desired_song_profile: { energy: 'high' },
+  },
+  recommendations: [
+    {
+      title: 'Test Song',
+      artist: 'Test Artist',
+      match_score: 85,
+      bpm: 128,
+      energy: 'High',
+      moods: ['Energetic'],
+      themes: ['Victory'],
+      matched_criteria: ['Energetic'],
+    },
+  ],
+  player_id: 'player-123',
+  metadata: {
+    used_sample_data: true,
+    timestamp: '2025-01-01T00:00:00Z',
+    request_id: 'req-123',
+    processed_at: '2025-01-01T00:00:01Z',
+  },
+};
+
+const agenticResult = {
+  success: true,
+  profile: {
+    player_name: 'TestPlayer',
+    game_reading: {
+      narrative:
+        'An explosive match with relentless aerial pressure and clutch saves.',
+      key_observations: [
+        'Dominant aerial presence',
+        'Consistent boost management',
+        'Strong rotation discipline',
+      ],
+      player_archetype: 'Aerial Ace',
+      emotional_arc: 'Tense buildup to triumphant finish',
+      song_search_direction:
+        'High energy electronic music with triumphant drops and soaring synths',
+    },
+    desired_song_profile: { energy: 'high' },
+  },
+  recommendations: [
+    {
+      title: 'Agentic Song',
+      artist: 'AI Artist',
+      match_score: 90,
+      bpm: 140,
+      energy: 'High',
+      moods: ['Intense'],
+      themes: ['Triumph'],
+      matched_criteria: ['Intense'],
+      llm_vibe: 'Arena energy',
+      llm_game_moments: ['Aerial goal'],
+    },
+  ],
+  player_id: 'player-456',
+  metadata: {
+    used_sample_data: false,
+    timestamp: '2025-01-01T00:00:00Z',
+    request_id: 'req-456',
+    processed_at: '2025-01-01T00:00:01Z',
+  },
+};
+
+// --- Tests ---
+
+describe('SongRecommendations', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders "Test with Sample Data" button', () => {
+    render(<SongRecommendations replayData={null} />);
+
+    expect(
+      screen.getByRole('button', { name: /test with sample data/i })
+    ).toBeInTheDocument();
+  });
+
+  describe('deterministic mode', () => {
+    it('renders categories grid and metrics after fetch', async () => {
+      global.fetch = jest.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => deterministicResult,
+      });
+
+      render(<SongRecommendations replayData={null} />);
+
+      // Click "Test with Sample Data"
+      fireEvent.click(
+        screen.getByRole('button', { name: /test with sample data/i })
+      );
+
+      await waitFor(() => {
+        // Categories should render
+        expect(screen.getByText('intensity')).toBeInTheDocument();
+        expect(screen.getByText('performance')).toBeInTheDocument();
+        expect(screen.getByText('teamwork')).toBeInTheDocument();
+        expect(screen.getByText('closeness')).toBeInTheDocument();
+
+        // Category values
+        expect(screen.getByText('High')).toBeInTheDocument();
+        expect(screen.getByText('Excellent')).toBeInTheDocument();
+        expect(screen.getByText('Good')).toBeInTheDocument();
+        expect(screen.getByText('Medium')).toBeInTheDocument();
+
+        // Metrics
+        expect(screen.getByText('Intensity Score')).toBeInTheDocument();
+        expect(screen.getByText('75')).toBeInTheDocument();
+        expect(screen.getByText('Performance Score')).toBeInTheDocument();
+        expect(screen.getByText('80')).toBeInTheDocument();
+        expect(screen.getByText('Teamwork Factor')).toBeInTheDocument();
+        expect(screen.getByText('60')).toBeInTheDocument();
+      });
+    });
+
+    it('does NOT render game_reading fields in deterministic mode', async () => {
+      global.fetch = jest.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => deterministicResult,
+      });
+
+      render(<SongRecommendations replayData={null} />);
+
+      fireEvent.click(
+        screen.getByRole('button', { name: /test with sample data/i })
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('75')).toBeInTheDocument();
+      });
+
+      // Agentic-specific content should NOT be present
+      expect(screen.queryByText('Aerial Ace')).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(/relentless aerial pressure/)
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByText('Tense buildup to triumphant finish')
+      ).not.toBeInTheDocument();
+    });
+
+    it('renders song cards', async () => {
+      global.fetch = jest.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => deterministicResult,
+      });
+
+      render(<SongRecommendations replayData={null} />);
+
+      fireEvent.click(
+        screen.getByRole('button', { name: /test with sample data/i })
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('song-card-0')).toBeInTheDocument();
+        expect(
+          screen.getByText('Test Song by Test Artist')
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('agentic mode', () => {
+    it('renders narrative, player_archetype, emotional_arc, key_observations, and song_search_direction', async () => {
+      global.fetch = jest.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => agenticResult,
+      });
+
+      render(<SongRecommendations replayData={null} />);
+
+      fireEvent.click(
+        screen.getByRole('button', { name: /test with sample data/i })
+      );
+
+      await waitFor(() => {
+        // Narrative
+        expect(
+          screen.getByText(
+            'An explosive match with relentless aerial pressure and clutch saves.'
+          )
+        ).toBeInTheDocument();
+
+        // Player Archetype
+        expect(screen.getByText('Aerial Ace')).toBeInTheDocument();
+
+        // Emotional Arc
+        expect(
+          screen.getByText('Tense buildup to triumphant finish')
+        ).toBeInTheDocument();
+
+        // Key Observations
+        expect(
+          screen.getByText('Dominant aerial presence')
+        ).toBeInTheDocument();
+        expect(
+          screen.getByText('Consistent boost management')
+        ).toBeInTheDocument();
+        expect(
+          screen.getByText('Strong rotation discipline')
+        ).toBeInTheDocument();
+
+        // Song Search Direction
+        expect(
+          screen.getByText(
+            'High energy electronic music with triumphant drops and soaring synths'
+          )
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('does NOT render categories or metrics in agentic mode', async () => {
+      global.fetch = jest.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => agenticResult,
+      });
+
+      render(<SongRecommendations replayData={null} />);
+
+      fireEvent.click(
+        screen.getByRole('button', { name: /test with sample data/i })
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Aerial Ace')).toBeInTheDocument();
+      });
+
+      // Deterministic-specific content should NOT be present
+      expect(screen.queryByText('Intensity Score')).not.toBeInTheDocument();
+      expect(screen.queryByText('Performance Score')).not.toBeInTheDocument();
+      expect(screen.queryByText('Teamwork Factor')).not.toBeInTheDocument();
+    });
+
+    it('renders agentic song cards', async () => {
+      global.fetch = jest.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => agenticResult,
+      });
+
+      render(<SongRecommendations replayData={null} />);
+
+      fireEvent.click(
+        screen.getByRole('button', { name: /test with sample data/i })
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('song-card-0')).toBeInTheDocument();
+        expect(
+          screen.getByText('Agentic Song by AI Artist')
+        ).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/src/__tests__/unit/SpotifySongCard.spec.tsx
+++ b/src/__tests__/unit/SpotifySongCard.spec.tsx
@@ -1,0 +1,194 @@
+// ABOUTME: Unit tests for SpotifySongCard component.
+// ABOUTME: Validates rendering of deterministic and agentic song fields.
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import SpotifySongCard from '@/components/SpotifySongCard';
+import { Song } from '@/types/spotify';
+
+// --- Mocks ---
+
+// Mock motion/react to render plain divs
+jest.mock('motion/react', () => ({
+  motion: {
+    div: ({
+      children,
+      ...props
+    }: {
+      children: React.ReactNode;
+      [key: string]: any;
+    }) => <div {...props}>{children}</div>,
+  },
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+// Mock lucide-react icons
+jest.mock('lucide-react', () => ({
+  ExternalLink: () => <span data-testid="icon-external-link">ExtLink</span>,
+  Music: () => <span data-testid="icon-music">Music</span>,
+  Maximize2: () => <span data-testid="icon-maximize">Max</span>,
+  Minimize2: () => <span data-testid="icon-minimize">Min</span>,
+}));
+
+// Mock UI primitives
+jest.mock('@/components/ui/card', () => {
+  const Card = ({
+    children,
+    className,
+  }: {
+    children: React.ReactNode;
+    className?: string;
+  }) => (
+    <div data-testid="card" className={className}>
+      {children}
+    </div>
+  );
+  Card.displayName = 'Card';
+  return { Card };
+});
+
+jest.mock('@/components/ui/button', () => {
+  const Button = ({
+    children,
+    ...props
+  }: {
+    children: React.ReactNode;
+    [key: string]: any;
+  }) => <button {...props}>{children}</button>;
+  Button.displayName = 'Button';
+  return { Button };
+});
+
+jest.mock('@/components/ui/badge', () => {
+  const Badge = ({
+    children,
+    className,
+    variant,
+  }: {
+    children: React.ReactNode;
+    className?: string;
+    variant?: string;
+  }) => (
+    <span data-testid="badge" className={className} data-variant={variant}>
+      {children}
+    </span>
+  );
+  Badge.displayName = 'Badge';
+  return { Badge };
+});
+
+// --- Fixtures ---
+
+const baseSong: Song = {
+  title: 'Midnight Drive',
+  artist: 'Synthwave Sam',
+  match_score: 85,
+  bpm: 128,
+  energy: 'High',
+  moods: ['Energetic', 'Uplifting'],
+  themes: ['Competition', 'Victory'],
+  matched_criteria: ['Energetic', 'Competition'],
+  source_url: 'https://open.spotify.com/track/abc123',
+};
+
+const agenticSong: Song = {
+  ...baseSong,
+  llm_vibe: 'Futuristic arena energy with a neon glow',
+  llm_game_moments: ['Aerial goal', 'Last-second save', 'Overtime winner'],
+};
+
+// --- Tests ---
+
+describe('SpotifySongCard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders core song fields (title, artist, match_score, bpm)', () => {
+    render(<SpotifySongCard song={baseSong} index={0} />);
+
+    expect(screen.getByText('Midnight Drive')).toBeInTheDocument();
+    expect(screen.getByText('by Synthwave Sam')).toBeInTheDocument();
+    expect(screen.getByText('Match: 85%')).toBeInTheDocument();
+    expect(screen.getByText('128 BPM • High')).toBeInTheDocument();
+  });
+
+  it('highlights matched moods and themes using matched_criteria', () => {
+    render(<SpotifySongCard song={baseSong} index={0} />);
+
+    // "Energetic" is in matched_criteria, should have a checkmark
+    const energeticBadge = screen.getByText((content, element) => {
+      return (
+        element?.tagName.toLowerCase() === 'span' &&
+        content.includes('Energetic') &&
+        (element?.textContent?.includes('\u2713') ?? false)
+      );
+    });
+    expect(energeticBadge).toBeInTheDocument();
+
+    // "Competition" is in matched_criteria for themes, should have a star
+    const competitionBadge = screen.getByText((content, element) => {
+      return (
+        element?.tagName.toLowerCase() === 'span' &&
+        content.includes('Competition') &&
+        (element?.textContent?.includes('\u2605') ?? false)
+      );
+    });
+    expect(competitionBadge).toBeInTheDocument();
+  });
+
+  it('renders matched criteria summary text', () => {
+    render(<SpotifySongCard song={baseSong} index={0} />);
+
+    expect(
+      screen.getByText('Matched: Energetic, Competition')
+    ).toBeInTheDocument();
+  });
+
+  it('renders llm_vibe when present (agentic song)', () => {
+    render(<SpotifySongCard song={agenticSong} index={0} />);
+
+    expect(
+      screen.getByText('Futuristic arena energy with a neon glow')
+    ).toBeInTheDocument();
+  });
+
+  it('renders llm_game_moments badges when present (agentic song)', () => {
+    render(<SpotifySongCard song={agenticSong} index={0} />);
+
+    expect(screen.getByText('Aerial goal')).toBeInTheDocument();
+    expect(screen.getByText('Last-second save')).toBeInTheDocument();
+    expect(screen.getByText('Overtime winner')).toBeInTheDocument();
+  });
+
+  it('omits agentic sections when those fields are absent', () => {
+    render(<SpotifySongCard song={baseSong} index={0} />);
+
+    // llm_vibe text should not appear
+    expect(
+      screen.queryByText('Futuristic arena energy with a neon glow')
+    ).not.toBeInTheDocument();
+
+    // llm_game_moments should not appear
+    expect(screen.queryByText('Aerial goal')).not.toBeInTheDocument();
+  });
+
+  it('renders quality badge based on match_score', () => {
+    render(<SpotifySongCard song={baseSong} index={0} />);
+
+    // 85% should get "Perfect Match"
+    expect(screen.getByText('Perfect Match')).toBeInTheDocument();
+  });
+
+  it('renders "Good Match" badge for scores between 60-79', () => {
+    const goodMatchSong: Song = {
+      ...baseSong,
+      match_score: 70,
+    };
+    render(<SpotifySongCard song={goodMatchSong} index={0} />);
+
+    expect(screen.getByText('Good Match')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/unit/spotify-types.spec.ts
+++ b/src/__tests__/unit/spotify-types.spec.ts
@@ -1,0 +1,58 @@
+// ABOUTME: Unit tests for type guard functions in the spotify types module.
+// ABOUTME: Validates isAgenticProfile and isDeterministicProfile discriminate correctly.
+
+import {
+  isAgenticProfile,
+  isDeterministicProfile,
+  DeterministicProfile,
+  AgenticProfile,
+} from '@/types/spotify';
+
+const deterministicProfile: DeterministicProfile = {
+  player_name: 'TestPlayer',
+  metrics: {
+    intensity_score: 75,
+    performance_score: 80,
+    teamwork_factor: 60,
+    game_outcome: 'win',
+  },
+  categories: {
+    intensity: 'High',
+    performance: 'Excellent',
+    teamwork: 'Good',
+    closeness: 'Medium',
+  },
+  desired_song_profile: { energy: 'high' },
+};
+
+const agenticProfile: AgenticProfile = {
+  player_name: 'TestPlayer',
+  game_reading: {
+    narrative: 'An intense aerial duel match with constant pressure.',
+    key_observations: ['Aggressive playstyle', 'High boost usage'],
+    player_archetype: 'Aerial Ace',
+    emotional_arc: 'Tense buildup to triumphant finish',
+    song_search_direction: 'High energy electronic with triumphant drops',
+  },
+  desired_song_profile: { energy: 'high' },
+};
+
+describe('isAgenticProfile', () => {
+  it('returns true for an agentic profile', () => {
+    expect(isAgenticProfile(agenticProfile)).toBe(true);
+  });
+
+  it('returns false for a deterministic profile', () => {
+    expect(isAgenticProfile(deterministicProfile)).toBe(false);
+  });
+});
+
+describe('isDeterministicProfile', () => {
+  it('returns true for a deterministic profile', () => {
+    expect(isDeterministicProfile(deterministicProfile)).toBe(true);
+  });
+
+  it('returns false for an agentic profile', () => {
+    expect(isDeterministicProfile(agenticProfile)).toBe(false);
+  });
+});

--- a/src/components/SongRecommendations.tsx
+++ b/src/components/SongRecommendations.tsx
@@ -1,4 +1,5 @@
-// components/SongRecommendations.tsx
+// ABOUTME: Component that fetches and displays music recommendations for replay players.
+// ABOUTME: Supports both deterministic (metrics/categories) and agentic (game_reading) profiles.
 'use client';
 
 import { useState, useRef, useEffect } from 'react';
@@ -17,8 +18,12 @@ import {
 } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
 import SpotifySongCard from './SpotifySongCard';
-// Replace the interface definitions at the top with this import:
-import { RecommendationResult, Player } from '../types/spotify';
+import {
+  RecommendationResult,
+  Player,
+  isAgenticProfile,
+  isDeterministicProfile,
+} from '../types/spotify';
 
 interface SongRecommendationsProps {
   replayData: any;
@@ -338,49 +343,110 @@ export default function SongRecommendations({
                     Recommendations for {selectedPlayer?.name}
                   </h3>
 
-                  {/* Performance Categories */}
-                  <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-4">
-                    {Object.entries(recommendations.profile.categories).map(
-                      ([key, value]) => (
-                        <div key={key} className="text-center">
-                          <div className="flex items-center justify-center gap-1 mb-1">
-                            {getCategoryIcon(key)}
-                            <span className="text-sm font-medium capitalize">
-                              {key}
-                            </span>
-                          </div>
-                          <Badge
-                            className={getCategoryColor(value)}
-                            variant="secondary"
-                          >
-                            {value}
-                          </Badge>
-                        </div>
-                      )
-                    )}
-                  </div>
+                  {/* Deterministic Profile: Performance Categories + Metrics */}
+                  {isDeterministicProfile(recommendations.profile) && (
+                    <>
+                      <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-4">
+                        {Object.entries(recommendations.profile.categories).map(
+                          ([key, value]) => (
+                            <div key={key} className="text-center">
+                              <div className="flex items-center justify-center gap-1 mb-1">
+                                {getCategoryIcon(key)}
+                                <span className="text-sm font-medium capitalize">
+                                  {key}
+                                </span>
+                              </div>
+                              <Badge
+                                className={getCategoryColor(value)}
+                                variant="secondary"
+                              >
+                                {value}
+                              </Badge>
+                            </div>
+                          )
+                        )}
+                      </div>
 
-                  {/* Metrics */}
-                  <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4 text-sm">
-                    <div className="text-center">
-                      <div className="font-medium">Intensity Score</div>
-                      <div className="text-2xl font-bold text-blue-600">
-                        {recommendations.profile.metrics.intensity_score}
+                      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4 text-sm">
+                        <div className="text-center">
+                          <div className="font-medium">Intensity Score</div>
+                          <div className="text-2xl font-bold text-blue-600">
+                            {recommendations.profile.metrics.intensity_score}
+                          </div>
+                        </div>
+                        <div className="text-center">
+                          <div className="font-medium">Performance Score</div>
+                          <div className="text-2xl font-bold text-green-600">
+                            {recommendations.profile.metrics.performance_score}
+                          </div>
+                        </div>
+                        <div className="text-center">
+                          <div className="font-medium">Teamwork Factor</div>
+                          <div className="text-2xl font-bold text-purple-600">
+                            {recommendations.profile.metrics.teamwork_factor}
+                          </div>
+                        </div>
+                      </div>
+                    </>
+                  )}
+
+                  {/* Agentic Profile: Game Reading */}
+                  {isAgenticProfile(recommendations.profile) && (
+                    <div className="space-y-4 mb-4">
+                      <div className="bg-muted/50 rounded-lg p-4">
+                        <p className="text-sm leading-relaxed">
+                          {recommendations.profile.game_reading.narrative}
+                        </p>
+                      </div>
+
+                      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <div>
+                          <div className="text-sm font-medium text-muted-foreground mb-1">
+                            Player Archetype
+                          </div>
+                          <div className="text-lg font-semibold">
+                            {
+                              recommendations.profile.game_reading
+                                .player_archetype
+                            }
+                          </div>
+                        </div>
+                        <div>
+                          <div className="text-sm font-medium text-muted-foreground mb-1">
+                            Emotional Arc
+                          </div>
+                          <div className="text-lg font-semibold">
+                            {recommendations.profile.game_reading.emotional_arc}
+                          </div>
+                        </div>
+                      </div>
+
+                      <div>
+                        <div className="text-sm font-medium text-muted-foreground mb-2">
+                          Key Observations
+                        </div>
+                        <ul className="list-disc list-inside space-y-1 text-sm">
+                          {recommendations.profile.game_reading.key_observations.map(
+                            (observation, idx) => (
+                              <li key={idx}>{observation}</li>
+                            )
+                          )}
+                        </ul>
+                      </div>
+
+                      <div>
+                        <div className="text-sm font-medium text-muted-foreground mb-1">
+                          Song Search Direction
+                        </div>
+                        <p className="text-sm">
+                          {
+                            recommendations.profile.game_reading
+                              .song_search_direction
+                          }
+                        </p>
                       </div>
                     </div>
-                    <div className="text-center">
-                      <div className="font-medium">Performance Score</div>
-                      <div className="text-2xl font-bold text-green-600">
-                        {recommendations.profile.metrics.performance_score}
-                      </div>
-                    </div>
-                    <div className="text-center">
-                      <div className="font-medium">Teamwork Factor</div>
-                      <div className="text-2xl font-bold text-purple-600">
-                        {recommendations.profile.metrics.teamwork_factor}
-                      </div>
-                    </div>
-                  </div>
+                  )}
                 </div>
 
                 {/* Song Recommendations */}

--- a/src/components/SpotifySongCard.tsx
+++ b/src/components/SpotifySongCard.tsx
@@ -1,4 +1,5 @@
-// components/SpotifySongCard.tsx
+// ABOUTME: Card component for displaying a song recommendation with Spotify embed.
+// ABOUTME: Supports both deterministic and agentic pipeline song fields.
 'use client';
 
 import { useState, useEffect } from 'react';
@@ -50,9 +51,7 @@ export default function SpotifySongCard({
 
   // Helper function to check if a mood/theme matches the criteria
   const isMatchedCriteria = (item: string): boolean => {
-    const matchedText = (song.matched_criteria_details || [])
-      .join(' ')
-      .toLowerCase();
+    const matchedText = (song.matched_criteria || []).join(' ').toLowerCase();
     return matchedText.includes(item.toLowerCase());
   };
 
@@ -168,7 +167,7 @@ export default function SpotifySongCard({
           <div className="flex flex-wrap gap-1 mb-3">
             {/* Moods */}
             {(song.moods || []).slice(0, 4).map((mood, idx) => {
-              const isMatched = (song.matched_criteria_details || [])
+              const isMatched = (song.matched_criteria || [])
                 .join(' ')
                 .toLowerCase()
                 .includes(mood.toLowerCase());
@@ -187,7 +186,7 @@ export default function SpotifySongCard({
 
             {/* Themes */}
             {(song.themes || []).slice(0, 3).map((theme, idx) => {
-              const isMatched = (song.matched_criteria_details || [])
+              const isMatched = (song.matched_criteria || [])
                 .join(' ')
                 .toLowerCase()
                 .includes(theme.toLowerCase());
@@ -204,10 +203,29 @@ export default function SpotifySongCard({
               );
             })}
           </div>
+          {/* Agentic LLM Fields */}
+          {song.llm_vibe && (
+            <p className="text-xs italic text-muted-foreground mb-2">
+              {song.llm_vibe}
+            </p>
+          )}
+          {song.llm_game_moments && song.llm_game_moments.length > 0 && (
+            <div className="flex flex-wrap gap-1 mb-3">
+              {song.llm_game_moments.map((moment, idx) => (
+                <Badge
+                  key={`moment-${idx}`}
+                  variant="outline"
+                  className="text-xs"
+                >
+                  {moment}
+                </Badge>
+              ))}
+            </div>
+          )}
           {/* Match Criteria */}
-          {(song.matched_criteria_details || []).length > 0 && (
+          {(song.matched_criteria || []).length > 0 && (
             <div className="text-xs text-muted-foreground mb-3">
-              Matched: {song.matched_criteria_details.slice(0, 2).join(', ')}
+              Matched: {song.matched_criteria.slice(0, 2).join(', ')}
             </div>
           )}
           {/* Actions */}

--- a/src/types/spotify.ts
+++ b/src/types/spotify.ts
@@ -1,4 +1,6 @@
-// types/spotify.ts
+// ABOUTME: Type definitions for Spotify integration and music recommendation system.
+// ABOUTME: Supports both deterministic and agentic recommendation pipeline modes.
+
 export interface Song {
   title: string;
   artist: string;
@@ -7,11 +9,28 @@ export interface Song {
   energy: string | number; // Allow both string ("High") and number (0.8)
   moods: string[];
   themes: string[];
-  matched_criteria_details: string[];
+  matched_criteria: string[];
   source_url?: string;
+  song_id?: number;
+  track_id?: string;
+  // Agentic pipeline fields
+  lastfm_tags?: Array<{ name: string; count: number }>;
+  llm_moods?: string[];
+  llm_themes?: string[];
+  llm_energy?: string;
+  llm_vibe?: string;
+  llm_game_moments?: string[];
 }
 
-export interface RecommendationProfile {
+export interface GameReading {
+  narrative: string;
+  key_observations: string[];
+  player_archetype: string;
+  emotional_arc: string;
+  song_search_direction: string;
+}
+
+export interface DeterministicProfile {
   player_name: string;
   metrics: {
     intensity_score: number;
@@ -28,11 +47,32 @@ export interface RecommendationProfile {
   desired_song_profile: any;
 }
 
+export interface AgenticProfile {
+  player_name: string;
+  game_reading: GameReading;
+  desired_song_profile: any;
+}
+
+export type RecommendationProfile = DeterministicProfile | AgenticProfile;
+
+export function isAgenticProfile(
+  profile: RecommendationProfile
+): profile is AgenticProfile {
+  return 'game_reading' in profile;
+}
+
+export function isDeterministicProfile(
+  profile: RecommendationProfile
+): profile is DeterministicProfile {
+  return 'metrics' in profile;
+}
+
 export interface RecommendationResult {
   success: boolean;
   profile: RecommendationProfile;
   recommendations: Song[];
   player_id: string;
+  game_reading?: GameReading;
   metadata: {
     used_sample_data: boolean;
     timestamp: string;


### PR DESCRIPTION
Fix frontend crash when Python backend returns agentic pipeline responses (no metrics/categories). Detect response shape via type guards and render accordingly. Also fixes latent bug: matched_criteria_details → matched_criteria to match actual API field name.